### PR TITLE
Add "main" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bin/",
     "dist/"
   ],
+  "main": "dist/js-yaml.js",
   "bin": {
     "js-yaml": "bin/js-yaml.js"
   },


### PR DESCRIPTION
This allows WebPack to automatically find the adjacent `js-yaml.min.js` when making an optimized build, which greatly reduces bundle size.